### PR TITLE
Allow for the addition of titles to tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ options
 - `grid` : grid dimensions to use (default is largest square grid)
 - `size` : size of figure (default `7`)
 - `axis` : which axis to index images with (default `0`)
+- `titles` : titles to add to each image (default `None`)

--- a/showit/showit.py
+++ b/showit/showit.py
@@ -1,6 +1,6 @@
 from numpy import ndarray, rollaxis, asarray, nan_to_num, ceil, sqrt, around
 
-def tile(imgs, cmap='gray', bar=False, nans=True, clim=None, grid=None, size=9, axis=0, fig=None):
+def tile(imgs, cmap='gray', bar=False, nans=True, clim=None, grid=None, size=9, axis=0, fig=None, titles=None):
     """
     Display a collection of images as a grid of tiles
 
@@ -40,6 +40,9 @@ def tile(imgs, cmap='gray', bar=False, nans=True, clim=None, grid=None, size=9, 
 
     fig : matplotlib figure, optional, default = None
         An existing figure to plot on
+
+    titles : list of str, optional, default = None
+        Titles to add to each plot in the grid
     """
     from matplotlib.pyplot import figure, colorbar
     from mpl_toolkits.axes_grid1 import ImageGrid
@@ -92,6 +95,9 @@ def tile(imgs, cmap='gray', bar=False, nans=True, clim=None, grid=None, size=9, 
     if ngrid < nimgs:
         raise ValueError("Total grid count %g too small for number of images %g" % (ngrid, nimgs))
 
+    if len(titles) != nimgs:
+        raise ValueError("Number of titles %g does equal number of images %g" % (len(titles), nimgs))
+
     g = ImageGrid(fig, 111, nrows_ncols=grid, axes_pad=axes_pad,
                   cbar_mode=cbar_mode, cbar_size="5%", cbar_pad="5%")
 
@@ -105,6 +111,9 @@ def tile(imgs, cmap='gray', bar=False, nans=True, clim=None, grid=None, size=9, 
             rng = abs(cb.vmax - cb.vmin) * 0.05
             cb.set_ticks([around(cb.vmin + rng, 1), around(cb.vmax - rng, 1)])
             cb.outline.set_visible(False)
+
+        if titles is not None:
+            g[i].set_title(titles[i])
 
         axes.append(ax)
 

--- a/showit/showit.py
+++ b/showit/showit.py
@@ -95,8 +95,9 @@ def tile(imgs, cmap='gray', bar=False, nans=True, clim=None, grid=None, size=9, 
     if ngrid < nimgs:
         raise ValueError("Total grid count %g too small for number of images %g" % (ngrid, nimgs))
 
-    if len(titles) != nimgs:
-        raise ValueError("Number of titles %g does equal number of images %g" % (len(titles), nimgs))
+    if titles is not None:
+        if len(titles) != nimgs:
+            raise ValueError("Number of titles %g does equal number of images %g" % (len(titles), nimgs))
 
     g = ImageGrid(fig, 111, nrows_ncols=grid, axes_pad=axes_pad,
                   cbar_mode=cbar_mode, cbar_size="5%", cbar_pad="5%")


### PR DESCRIPTION
This simple modification allows users to add a title to each image plotted by tile.

Usage looks like:

```
from numpy import random
from showit import tile

ims = random.rand(9, 25, 25, 3)
tile(ims, titles=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'g']);
```

which displays:

![image](https://user-images.githubusercontent.com/2704460/66227388-f2d1e880-e691-11e9-97bf-af6315e351a9.png)

